### PR TITLE
precedence issue with "and" in Set/Product.pm

### DIFF
--- a/lib/Set/Product.pm
+++ b/lib/Set/Product.pm
@@ -12,8 +12,8 @@ $VERSION = eval $VERSION;
 
 our @EXPORT_OK = qw(product);
 
-my $want_xs = ! $ENV{SET_PRODUCT_PP} and ! $ENV{PURE_PERL}
-    and eval "use Set::Product::XS; 1";
+my $want_xs = ! $ENV{SET_PRODUCT_PP} && ! $ENV{PURE_PERL}
+    && eval "use Set::Product::XS; 1";
 
 no warnings qw(redefine);
 

--- a/t/03_pp_vs_xs.t
+++ b/t/03_pp_vs_xs.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More;
+
+subtest 'use Set::Product::PP::product by default if Set::Product::XS is not installed' => sub {
+   eval "use Set::Product::XS; 1"
+      ? ( plan skip_all => 'Set::Product::XS is installed' )
+      : ( plan tests => 1 );
+
+    require Set::Product;
+    ok(\&Set::Product::product == \&Set::Product::PP::product, 
+       'when Set::Product::XS is not installed product defaults to Set::Product::PP::product'
+    );
+};
+
+done_testing;


### PR DESCRIPTION
fix a precedence issue with "and" in Set/Product.pm where Set::Product::XS::product was still chosen as the default product implementation when Set::Product::XS was not actually installed on my machine. 

The issue here is that this statement:

```
my $want_xs = ! $ENV{SET_PRODUCT_PP} and ! $ENV{PURE_PERL}
    and eval "use Set::Product::XS; 1";
```

can return true even if Set::Product::XS is not installed because 'and' does not bind tightly enough. 
